### PR TITLE
handle multiple Www-Authenticate headers correctly

### DIFF
--- a/httpntlm_test.go
+++ b/httpntlm_test.go
@@ -41,6 +41,7 @@ func Test_AuthenticationSuccess(t *testing.T) {
 			}
 		} else {
 			challenge, _ := session.GenerateChallengeMessage()
+			w.Header().Add("WWW-Authenticate", `Basic realm="test"`)
 			w.Header().Add("WWW-Authenticate", "NTLM "+encBase64(challenge.Bytes()))
 			w.WriteHeader(401)
 		}


### PR DESCRIPTION
select only NTLM auth scheme in case multiple Www-Authenticate headers are present.

Closes #10 